### PR TITLE
Feat/self ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ As mentioned above, the database deploys into an existing base network:
 | component                       | The component this database will serve                                    | -                     | yes      |
 | deployment_identifier           | An identifier for this instantiation                                      | -                     | yes      |
 | private_network_cidr            | The CIDR of the private network allowed access to the ELB                 | -                     | yes      |
+| ingress_self                    | Whether to create a self-referencing ingress rule on the security group   | "no"                  | no       |
 | private_subnet_ids              | The IDs of the private subnets to deploy the database into                | -                     | yes      |
 | database_instance_class         | The instance type of the RDS instance.                                    | -                     | yes      |
 | database_version                | The database version. If omitted, it lets Amazon decide.                  | -                     | no       |

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -7,6 +7,8 @@ deployment_identifier: "%{hiera('deployment_identifier')}"
 work_directory: 'build'
 configuration_directory: "%{hiera('work_directory')}/%{hiera('source_directory')}"
 
+ingress_self: "no"
+egress_self: "no"
 private_network_cidr: '10.0.0.0/8'
 
 database_instance_class: 'db.t2.micro'

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -7,8 +7,7 @@ deployment_identifier: "%{hiera('deployment_identifier')}"
 work_directory: 'build'
 configuration_directory: "%{hiera('work_directory')}/%{hiera('source_directory')}"
 
-ingress_self: "no"
-egress_self: "no"
+ingress_self: "yes"
 private_network_cidr: '10.0.0.0/8'
 
 database_instance_class: 'db.t2.micro'

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -5,6 +5,7 @@ vars:
   region: "%{hiera('region')}"
 
   private_network_cidr: "%{hiera('private_network_cidr')}"
+  ingress_self: "%{hiera('ingress_self')}"
 
   component: "%{hiera('component')}"
   deployment_identifier: "%{hiera('deployment_identifier')}"

--- a/security_group.tf
+++ b/security_group.tf
@@ -13,17 +13,25 @@ resource "aws_security_group" "postgres_database_security_group" {
     from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
-    self      = var.ingress_self == "yes" ? true : false
     cidr_blocks = [
       var.private_network_cidr
     ]
+  }
+
+  dynamic "ingress" {
+    for_each = var.ingress_self == "yes" ? [1] : []
+    content {
+      self      = true
+      from_port = 0
+      to_port   = 65535
+      protocol  = "tcp"
+    }
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    self        = var.egress_self == "yes" ? true : false
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -13,8 +13,17 @@ resource "aws_security_group" "postgres_database_security_group" {
     from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
+    self      = var.ingress_self == "yes" ? true : false
     cidr_blocks = [
       var.private_network_cidr
     ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = var.egress_self == "yes" ? true : false
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -23,7 +23,6 @@ module "rds_postgres" {
   database_master_user = var.database_master_user
   private_network_cidr = var.private_network_cidr
   ingress_self = var.ingress_self
-  egress_self = var.egress_self
 
   snapshot_identifier = var.snapshot_identifier
   backup_retention_period = var.backup_retention_period

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -22,6 +22,8 @@ module "rds_postgres" {
   database_master_user_password = var.database_master_user_password
   database_master_user = var.database_master_user
   private_network_cidr = var.private_network_cidr
+  ingress_self = var.ingress_self
+  egress_self = var.egress_self
 
   snapshot_identifier = var.snapshot_identifier
   backup_retention_period = var.backup_retention_period

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -1,7 +1,6 @@
 variable "region" {}
 variable "private_network_cidr" {}
 variable "ingress_self" {}
-variable "egress_self" {}
 
 variable "component" {}
 variable "deployment_identifier" {}

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -1,5 +1,7 @@
 variable "region" {}
 variable "private_network_cidr" {}
+variable "ingress_self" {}
+variable "egress_self" {}
 
 variable "component" {}
 variable "deployment_identifier" {}

--- a/spec/rds_spec.rb
+++ b/spec/rds_spec.rb
@@ -34,9 +34,12 @@ describe 'RDS' do
     its('backup_retention_period') {should eq 14}
     its('preferred_backup_window') {should eq '01:00-03:00'}
     its('preferred_maintenance_window') {should eq 'mon:03:01-mon:05:00'}
+  end
 
-    its('egress.cidr_blocks') {should eq ['0.0.0.0/0']}
-    its('ingress_self') {should eq 'no'}
-    its('egress_self') {should eq 'no'}
+  context 'security_group' do
+    subject {
+      security_group("database-security-group-#{component}-#{deployment_identifier}")
+    }
+    its(:inbound) { should be_opened(22).protocol('tcp').for("database-security-group-#{component}-#{deployment_identifier}") }
   end
 end

--- a/spec/rds_spec.rb
+++ b/spec/rds_spec.rb
@@ -34,5 +34,9 @@ describe 'RDS' do
     its('backup_retention_period') {should eq 14}
     its('preferred_backup_window') {should eq '01:00-03:00'}
     its('preferred_maintenance_window') {should eq 'mon:03:01-mon:05:00'}
+
+    its('egress.cidr_blocks') {should eq ['0.0.0.0/0']}
+    its('ingress_self') {should eq 'no'}
+    its('egress_self') {should eq 'no'}
   end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,14 @@ variable "private_subnet_ids" {
 variable "private_network_cidr" {
   description = "The CIDR of the private network allowed access to the database."
 }
+variable "ingress_self" {
+  description = "If yes, the security group itself will be added as a source to this ingress rule."
+  default = "no"
+}
+variable "egress_self" {
+  description = "If yes, the security group itself will be added as a source to this egress rule."
+  default = "no"
+}
 
 variable "component" {
   description = "The component this database will serve."

--- a/variables.tf
+++ b/variables.tf
@@ -12,10 +12,6 @@ variable "ingress_self" {
   description = "If yes, the security group itself will be added as a source to this ingress rule."
   default = "no"
 }
-variable "egress_self" {
-  description = "If yes, the security group itself will be added as a source to this egress rule."
-  default = "no"
-}
 
 variable "component" {
   description = "The component this database will serve."


### PR DESCRIPTION
Hello,

I hope you are well! Thanks so much for putting these great modules together. 

With this change, you will be able to set an optional configuration variable `ingress_self` on the module, resulting in an additional self-referencing Inbound rule created on the Security Group used by the RDS instance (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#self), as well as adding a default all-out egress. 

The specific use case: https://docs.aws.amazon.com/glue/latest/dg/setup-vpc-for-glue-access.html
"To enable AWS Glue to communicate between its components, specify a security group with a self-referencing inbound rule for all TCP ports. By creating a self-referencing rule, you can restrict the source to the same security group in the VPC, and it's not open to all networks. " ... "Add a rule for outbound traffic also. Either open outbound traffic to all ports... ".

I contemplated making the outbound also restricted to the security group itself (self is also supported), but as it's the egress, I thought that having an open default shouldn't do any harm. 

Please, let me know your thoughts! 


