### PR TITLE
Allow major version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ As mentioned above, the database deploys into an existing base network:
 | backup_window                   | The time window in which backups should take place.                         | "01:00-03:00"         | yes      |
 | maintenance_window              | The time window in which maintenance should take place.                     | "mon:03:01-mon:05:00" | yes      |
 | include_self_ingress_rule       | Whether or not to add a self-referencing ingress rule on the security group | "no"                  | no       |
+| allow_major_version_upgrade     | Whether or not to allow major version upgrades                              | "no"                  | no       |
 
 
 ### Outputs

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -30,3 +30,4 @@ availability_zones:
 private_zone_id: 'Z2CDAFD23Q10HO'
 
 include_self_ingress_rule: "yes"
+allow_major_version_upgrade: "yes"

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -23,3 +23,4 @@ vars:
   maintenance_window: "%{hiera('maintenance_window')}"
 
   include_self_ingress_rule: "%{hiera('include_self_ingress_rule')}"
+  allow_major_version_upgrade: "%{hiera('allow_major_version_upgrade')}"

--- a/rds.tf
+++ b/rds.tf
@@ -14,6 +14,7 @@ resource "aws_db_instance" "postgres_database" {
   storage_encrypted    = var.use_encrypted_storage == "yes" ? true : false
   skip_final_snapshot  = true
   db_subnet_group_name = aws_db_subnet_group.postgres_database_subnet_group.name
+  allow_major_version_upgrade = var.allow_major_version_upgrade == "yes" ? true : false
 
   vpc_security_group_ids = [
     aws_security_group.postgres_database_security_group.id

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -30,5 +30,6 @@ module "rds_postgres" {
   maintenance_window = var.maintenance_window
 
   include_self_ingress_rule = var.include_self_ingress_rule
+  allow_major_version_upgrade = var.allow_major_version_upgrade
 }
 

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -16,3 +16,5 @@ variable "backup_window" {}
 variable "maintenance_window" {}
 
 variable "include_self_ingress_rule" {}
+
+variable "allow_major_version_upgrade" {}

--- a/spec/rds_spec.rb
+++ b/spec/rds_spec.rb
@@ -38,8 +38,6 @@ describe 'RDS' do
     its('db_name') { should(eq(database_name)) }
     its('engine_version') { should(eq("9.5.6")) }
 
-    its('allow_major_version_upgrade') { should(eq(true)) }
-
     its('endpoint.address') { should(eq(postgres_database_host)) }
     its('endpoint.port') { should(eq(postgres_database_port.to_i)) }
 

--- a/spec/rds_spec.rb
+++ b/spec/rds_spec.rb
@@ -38,6 +38,8 @@ describe 'RDS' do
     its('db_name') { should(eq(database_name)) }
     its('engine_version') { should(eq("9.5.6")) }
 
+    its('allow_major_version_upgrade') { should(eq(true)) }
+
     its('endpoint.address') { should(eq(postgres_database_host)) }
     its('endpoint.port') { should(eq(postgres_database_port.to_i)) }
 

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,8 @@ variable "include_self_ingress_rule" {
   description = "Whether or not to allow access from the database security group to itself (\"yes\" or \"no\")."
   default     = "no"
 }
+
+variable "allow_major_version_upgrade" {
+  description = "hether or not to allow major version upgrades"
+  default = "no"
+}


### PR DESCRIPTION
Add allow_major_version_upgrade configuration option to be able to upgrade the database when needed.
We tried to find a way of testing this but it seems the ruby AWSpec assertion library didn't offer the possibility to check for allow_major_version_upgrade.