### PR TITLE
[TECH] Add auto_minor_version_upgrade and storage_type options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ As mentioned above, the database deploys into an existing base network:
 | maintenance_window              | The time window in which maintenance should take place.                     | "mon:03:01-mon:05:00" | yes      |
 | include_self_ingress_rule       | Whether or not to add a self-referencing ingress rule on the security group | "no"                  | no       |
 | allow_major_version_upgrade     | Whether or not to allow major version upgrades                              | "no"                  | no       |
+| auto_minor_version_upgrade      | Whether or not to enable auto minor version upgrades                        | "no"                  | no       |
+| storage_type                    | The storage type of the RDS instance ("standard" or "gp2" )                 | "standard"            | no       |
 
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As mentioned above, the database deploys into an existing base network:
 | maintenance_window              | The time window in which maintenance should take place.                     | "mon:03:01-mon:05:00" | yes      |
 | include_self_ingress_rule       | Whether or not to add a self-referencing ingress rule on the security group | "no"                  | no       |
 | allow_major_version_upgrade     | Whether or not to allow major version upgrades                              | "no"                  | no       |
-| auto_minor_version_upgrade      | Whether or not to enable auto minor version upgrades                        | "no"                  | no       |
+| auto_minor_version_upgrade      | Whether or not to enable auto minor version upgrades                        | "yes"                 | no       |
 | storage_type                    | The storage type of the RDS instance ("standard" or "gp2" )                 | "standard"            | no       |
 
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -31,3 +31,5 @@ private_zone_id: 'Z2CDAFD23Q10HO'
 
 include_self_ingress_rule: "yes"
 allow_major_version_upgrade: "yes"
+auto_minor_version_upgrade: "yes"
+storage_type: "gp2"

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -24,3 +24,5 @@ vars:
 
   include_self_ingress_rule: "%{hiera('include_self_ingress_rule')}"
   allow_major_version_upgrade: "%{hiera('allow_major_version_upgrade')}"
+  auto_minor_version_upgrade: "%{hiera('auto_minor_version_upgrade')}"
+  storage_type: "%{hiera('storage_type')}"

--- a/rds.tf
+++ b/rds.tf
@@ -1,7 +1,7 @@
 resource "aws_db_instance" "postgres_database" {
   identifier           = "db-instance-${var.component}-${var.deployment_identifier}"
   allocated_storage    = var.allocated_storage
-  storage_type         = "standard"
+  storage_type         = var.storage_type
   engine               = "postgres"
   engine_version       = var.database_version
   instance_class       = var.database_instance_class
@@ -15,6 +15,7 @@ resource "aws_db_instance" "postgres_database" {
   skip_final_snapshot  = true
   db_subnet_group_name = aws_db_subnet_group.postgres_database_subnet_group.name
   allow_major_version_upgrade = var.allow_major_version_upgrade == "yes" ? true : false
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade == "yes" ? true : false
 
   vpc_security_group_ids = [
     aws_security_group.postgres_database_security_group.id

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -32,5 +32,7 @@ module "rds_postgres" {
 
   include_self_ingress_rule = var.include_self_ingress_rule
   allow_major_version_upgrade = var.allow_major_version_upgrade
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  storage_type = var.storage_type
 }
 

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -18,3 +18,5 @@ variable "maintenance_window" {}
 variable "include_self_ingress_rule" {}
 
 variable "allow_major_version_upgrade" {}
+variable "auto_minor_version_upgrade" {}
+variable "storage_type" {}

--- a/spec/rds_spec.rb
+++ b/spec/rds_spec.rb
@@ -5,6 +5,7 @@ describe 'RDS' do
   let(:deployment_identifier) { vars.deployment_identifier }
 
   let(:database_name) { vars.database_name }
+  let(:storage_type) { vars.storage_type }
 
   let(:vpc_id) { output_for(:prerequisites, 'vpc_id') }
   let(:postgres_database_port) do
@@ -46,6 +47,7 @@ describe 'RDS' do
     its('preferred_maintenance_window') do
       should(eq('mon:03:01-mon:05:00'))
     end
+    its('storage_type') { should(eq(storage_type)) }
   end
 
   context 'security_group' do

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,21 @@ variable "include_self_ingress_rule" {
 }
 
 variable "allow_major_version_upgrade" {
-  description = "hether or not to allow major version upgrades"
+  description = "Whether or not to allow major version upgrades"
   default = "no"
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Whether or not to enable auto minor version upgrades"
+  default = "no"
+}
+
+variable "storage_type" {
+  description = " (Optional) One of standard(magnetic), gp2(general purpose SSD)."
+  default = "standard"
+
+  validation {
+    condition     = contains(["standard", "gp2"], var.storage_type)
+    error_message = "Must be one of standard or gp2. Provisioned IOPS (io1) not yet supported."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,11 +78,11 @@ variable "allow_major_version_upgrade" {
 
 variable "auto_minor_version_upgrade" {
   description = "Whether or not to enable auto minor version upgrades"
-  default = "no"
+  default = "yes"
 }
 
 variable "storage_type" {
-  description = " (Optional) One of standard(magnetic), gp2(general purpose SSD)."
+  description = "The type of storage to use, either \"standard\" (magnetic) or \"gp2\" (general purpose SSD)."
   default = "standard"
 
   validation {


### PR DESCRIPTION
This enables selecting the storage type "standard" or "gp2"(it was locked to "standard").  The "io1" storage type is not included because it was more work to add (also needs iops option https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#iops).

The auto_minor_version_upgrade option is defaulting to "no" to avoid downtime/database restarts. The default value was "true" which meant AWS was automatically upgrading the minor version of the DB(in the maintenance window).

