### PR TITLE
Update hashicorp/aws provider version to make it consistent with previous changes

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.33"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
This PR is to make the required version of the `hashicorp/aws` provider consistent with the previous `db_name` related code changes.
The version 3.33 on the user module wouldn't work anymore. See error: 
```
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/service_database/rds.tf line 26, in resource "aws_db_instance" "postgres_database":
│   26:   db_name  = var.database_name
│ 
│ An argument named "db_name" is not expected here.
╵
```