### PR TITLE
Use expand/contract when security groups are renamed

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -36,4 +36,8 @@ resource "aws_security_group" "postgres_database_security_group" {
       "0.0.0.0/0"
     ]
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.29"
     }
   }
 }


### PR DESCRIPTION
If you are using this module after upgrading to a newer version of the `hashicorp/aws` provider, you can see the `name_prefix` is added to the security group. This causes a destroy-create of the resource.

Even using new values for `var.component`/`var.identifier` can cause a renaming, and so a destroy-create.

The `destroy` on the security might not work if there are dependant objects on it (ie. network interfaces).

https://github.com/hashicorp/terraform-provider-aws/issues/1671 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#recreating-a-security-group

A newer version of the `hashicorp/aws` used in this PR contains the fix for this issue. In these cases it would create the new security group, link it to the dependant objects, detach the old security group and destroy it.