### PR TITLE
Use name_prefix instead of name to avoid clashing on creation

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "postgres_database_security_group" {
-  name        = "database-security-group-${var.component}-${var.deployment_identifier}"
+  name_prefix = "database-security-group-${var.component}-${var.deployment_identifier}-"
   description = "Default security group for ${var.component} PostgreSQL database instance with deployment identifier ${var.deployment_identifier} allowing access from private network."
   vpc_id      = var.vpc_id
 

--- a/spec/integration/full_spec.rb
+++ b/spec/integration/full_spec.rb
@@ -44,10 +44,9 @@ describe 'full' do
     it { is_expected.to(exist) }
 
     it 'has a security group' do
-      security_group_name =
-        "database-security-group-#{component}-#{deployment_identifier}"
+      security_group_name_tag = "sg-database-#{component}-#{deployment_identifier}"
       expect(database)
-        .to(have_security_group(security_group_name))
+        .to(have_security_group(security_group_name_tag))
     end
 
     it 'has a name tag' do
@@ -95,7 +94,7 @@ describe 'full' do
   describe 'security_group' do
     subject do
       security_group(
-        "database-security-group-#{component}-#{deployment_identifier}"
+        "sg-database-#{component}-#{deployment_identifier}"
       )
     end
 
@@ -104,7 +103,7 @@ describe 'full' do
         .to(be_opened(22)
               .protocol('tcp')
               .for(
-                "database-security-group-#{component}-#{deployment_identifier}"
+                "sg-database-#{component}-#{deployment_identifier}"
               ))
     end
   end

--- a/spec/unit/security_group_spec.rb
+++ b/spec/unit/security_group_spec.rb
@@ -27,11 +27,11 @@ describe 'security group' do
               .once)
     end
 
-    it 'includes the component and deployment identifier in the name' do
+    it 'includes the component and deployment identifier in the name_prefix' do
       expect(@plan)
         .to(include_resource_creation(type: 'aws_security_group')
               .with_attribute_value(
-                :name,
+                :name_prefix,
                 including(component)
                   .and(including(deployment_identifier))
               ))


### PR DESCRIPTION
The lifecycle meta-argument `create_before_destroy` on the security group will make it try to create the new security group first and destroy the old one afterwards.

If the name of the resource is fixed then you would get an error 'Resource with that name already exists'. 

If we use `name_prefix` instead of `name` then terraform would append a random suffix to the name, so the security group name would be like `db-instance-${var.component}-${var.deployment_identifier}-<random-number>` 

Authors: @jordanrobinson @francesco-losciale